### PR TITLE
New release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) 
+(modification: no type change headlines) and this project adheres to 
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.0] - 2017-10-11
+- Initial release
+
+
+

--- a/README.md
+++ b/README.md
@@ -7,11 +7,38 @@ pairing cryptography library](https://github.com/zcash/bn), implementing an effi
 
 ## Installation
 
-TODO
+`npm install rustbn.js`
 
 ## Usage
 
-TODO
+Require the module:
+
+```
+const bn128Module = require('rustbn.js')
+```
+
+Curve Addition
+
+```
+const ecAddPrecompile = bn128Module.cwrap('ec_add', 'string', ['string'])
+var inputHexStr = '...'
+let result = ecAddPrecompile(inputHexStr)
+```
+
+Curve Multiplication
+
+```
+const ecMulPrecompile = bn128Module.cwrap('ec_mul', 'string', ['string'])
+var inputHexStr = '...'
+let result = ecMulPrecompile(inputHexStr)
+```
+
+Curve Pairing
+```
+const ecPairingPrecompile = bn128Module.cwrap('ec_pairing', 'string', ['string'])
+var inputHexStr = '...'
+let result = ecPairingPrecompile(inputHexStr)
+```
 
 ## Developer
 


### PR DESCRIPTION
Initial release in the context of other versioned Byzantium releases along with the ``ethereumjs-vm`` release, will be published on npm after merge.

See: https://github.com/ethereumjs/ethereumjs-vm/issues/209