### PR TITLE
sed validation

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,12 @@ all:
 	cargo build --target=asmjs-unknown-emscripten --release
 	mkdir -p lib
 	find target/asmjs-unknown-emscripten/release -type f -name "rustbn-js.js" | xargs -I {} cp {} lib/index.asm.js
+	@res=$$(sed -n '/run()$$/p' lib/index.asm.js | wc -l); \
+	if [ $$res == "0" ]; then \
+		echo "ERROR: could not find run() function in generated code"; \
+		exit 1; \
+	fi\
+
 	sed -ibak 's/run()$$/Module\["arguments"\]=\[\];run();module\.exports=Module;/' lib/index.asm.js
 
 wasm:


### PR DESCRIPTION
Make sure sed have at least 1 match, if the string is not found then stop and show error. Fixes https://github.com/ethereumjs/rustbn.js/issues/12