### PR TITLE
Specify ethereum-bn128.rs tag, use array instead of BytesRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ authors = ["holgerd77 <Holger.Drewes@gmail.com>",
 publish = false
 
 [dependencies]
-ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs" }
-parity-bytes = { git = "https://github.com/paritytech/parity-common" }
+ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.0" }
 rustc-hex = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 extern crate ethereum_bn128;
-extern crate parity_bytes as bytes;
 extern crate rustc_hex;
 
 use std::ffi::CStr;
@@ -8,16 +7,14 @@ use std::os::raw::c_char;
 use rustc_hex::FromHex;
 use rustc_hex::ToHex;
 
-use bytes::BytesRef;
-
 #[no_mangle]
 pub fn ec_mul(input_hex_ptr: *const c_char) -> *const c_char {
     let input_hex = unsafe { CStr::from_ptr(input_hex_ptr) };
     let input_str: &str = input_hex.to_str().unwrap();
     let input_parsed = FromHex::from_hex(input_str).unwrap();
 
-    let mut output = vec![0u8; 64];
-    match ethereum_bn128::bn128_mul(&input_parsed[..], &mut BytesRef::Fixed(&mut output[..])) {
+    let mut output = [0u8; 64];
+    match ethereum_bn128::bn128_mul(&input_parsed[..], &mut output) {
         Ok(_) => {
             let mut output_hex = output.to_hex();
             output_hex.push_str("\0");
@@ -33,8 +30,8 @@ pub fn ec_add(input_hex_ptr: *const c_char) -> *const c_char {
     let input_str: &str = input_hex.to_str().unwrap();
     let input_parsed = FromHex::from_hex(input_str).unwrap();
 
-    let mut output = vec![0u8; 64];
-    match ethereum_bn128::bn128_add(&input_parsed[..], &mut BytesRef::Fixed(&mut output[..])) {
+    let mut output = [0u8; 64];
+    match ethereum_bn128::bn128_add(&input_parsed[..], &mut output) {
         Ok(_) => {
             let mut output_hex = output.to_hex();
             output_hex.push_str("\0");
@@ -50,8 +47,8 @@ pub fn ec_pairing(input_hex_ptr: *const c_char) -> *const c_char {
     let input_str: &str = input_hex.to_str().unwrap();
     let input_parsed = FromHex::from_hex(input_str).unwrap();
 
-    let mut output = vec![0u8; 32];
-    match ethereum_bn128::bn128_pairing(&input_parsed[..], &mut BytesRef::Fixed(&mut output[..])) {
+    let mut output = [0u8; 32];
+    match ethereum_bn128::bn128_pairing(&input_parsed[..], &mut output) {
         Ok(_) => {
             let mut output_hex = output.to_hex();
             output_hex.push_str("\0");


### PR DESCRIPTION
specify branch `0.1.0` for `ethereum-bn128.rs.
use array instead of BytesRef when using `ethereum-bn128.rs` functions.

*Note*: this is still work in progress because there is a compilator error related to emscipten.